### PR TITLE
Add cl (Cell Ontology) to collection

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -51,6 +51,7 @@
   - civic.sid
   - civic.tid
   - civic.vid
+  - cl
   - clinicaltrials
   - clinvar
   - clinvar.record


### PR DESCRIPTION
## Summary
- Adds the `cl` (Cell Ontology) prefix from https://bioregistry.io/registry/cl to `collection.yaml`
- To support adding Cell Ontology annotations, related to https://github.com/nf-osi/nf-research-tools-schema/issues/170

## Test plan
- [ ] Automated PR validation workflow passes (checks prefix validity, regex, duplicates, resolver)