### PR TITLE
Fix fork PR validation: safe read-only validate + trusted comment

### DIFF
--- a/.github/workflows/comment_validation_results.yml
+++ b/.github/workflows/comment_validation_results.yml
@@ -1,0 +1,142 @@
+name: Comment Validation Results
+
+# Runs after "Validate Bioregistry Rules" finishes. Because it is triggered by
+# workflow_run, it executes from the base repository (main) with the base repo's
+# token and secrets, NOT the PR's code. It only reads the artifact the validation
+# job produced and posts a comment, so fork PR code never runs in this trusted
+# context. This is the safe counterpart to the read-only validation workflow.
+on:
+  workflow_run:
+    workflows: ["Validate Bioregistry Rules"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Only act on validation runs that were triggered by a pull request.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download validation results
+        uses: actions/download-artifact@v4
+        with:
+          name: validation-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: results
+
+      - name: Create Pull Request Comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const dir = 'results';
+            const read = (name) => {
+              try {
+                return fs.readFileSync(`${dir}/${name}`, 'utf8');
+              } catch (e) {
+                return null;
+              }
+            };
+
+            const prNumberRaw = read('pr_number.txt');
+            const prNumber = prNumberRaw ? parseInt(prNumberRaw.trim(), 10) : NaN;
+            if (!prNumber) {
+              core.info('No PR number found in artifact; skipping comment.');
+              return;
+            }
+
+            let message = '## Bioregistry Collection Issues\n\n';
+            let hasIssues = false;
+
+            const missingPatterns = read('missing_patterns.txt');
+            if (missingPatterns) {
+              message += '### Missing Regex Patterns\n\n';
+              message += 'The following resources are missing regex patterns:\n\n';
+              message += '```\n';
+              message += missingPatterns;
+              message += '\n```\n\n';
+              message += 'Please check if these resources are correctly registered in bioregistry.io.\n\n';
+              hasIssues = true;
+            }
+
+            const duplicates = read('duplicates.txt');
+            if (duplicates) {
+              message += '### Duplicate Resources\n\n';
+              message += 'The following resources appear multiple times in collection.yaml:\n\n';
+              message += '```\n';
+              message += duplicates;
+              message += '\n```\n\n';
+              message += 'Please remove the duplicate entries.\n\n';
+              hasIssues = true;
+            }
+
+            const invalidPrefixes = read('invalid_prefixes.txt');
+            if (invalidPrefixes) {
+              message += '### Invalid Prefixes\n\n';
+              message += 'The following prefixes are not registered in bioregistry.io:\n\n';
+              message += '```\n';
+              message += invalidPrefixes;
+              message += '\n```\n\n';
+              message += 'Please check if these prefixes are correct or need to be registered.\n\n';
+              hasIssues = true;
+            }
+
+            // Parse validation.log for missing resolver and deprecated resources
+            const log = read('validation.log');
+            if (log) {
+              // Extract cross-interference test results
+              const interferenceMatch = log.match(/--- Cross-Interference Test Report ---\s+([\s\S]*?)--------------------------------------/);
+              if (interferenceMatch && interferenceMatch[1]) {
+                const interferenceReport = interferenceMatch[1].trim();
+                if (interferenceReport && !interferenceReport.includes('No cross-interference issues detected')) {
+                  message += '### Cross-Interference Test Results\n\n';
+                  message += 'The following regexes have been identified as causing cross-interference and have been wrapped in non-capturing groups:\n\n';
+                  message += '```\n';
+                  message += interferenceReport;
+                  message += '\n```\n\n';
+                  hasIssues = true;
+                }
+              }
+
+              // Extract missing resolver resources
+              const missingResolverMatch = log.match(/Missing resolver for the following resources:\s+([\s\S]*?)(?=Deprecated resources detected:|$)/);
+              if (missingResolverMatch && missingResolverMatch[1]) {
+                const missingResolver = missingResolverMatch[1].trim().split('\n').filter(Boolean);
+                if (missingResolver.length > 0) {
+                  message += '### Missing Resolver\n\n';
+                  message += 'The following resources do not have a resolver (uri_format) in bioregistry.io:\n\n';
+                  message += '```\n';
+                  message += missingResolver.join('\n');
+                  message += '\n```\n\n';
+                  message += 'Please check if these resources should have a resolver or be removed.\n\n';
+                  hasIssues = true;
+                }
+              }
+
+              // Extract deprecated resources
+              const deprecatedMatch = log.match(/Deprecated resources detected:\s+([\s\S]*?)(?=$)/);
+              if (deprecatedMatch && deprecatedMatch[1]) {
+                const deprecated = deprecatedMatch[1].trim().split('\n').filter(Boolean);
+                if (deprecated.length > 0) {
+                  message += '### Deprecated Resources (Warning)\n\n';
+                  message += 'The following resources or prefixes are marked as deprecated in bioregistry.io:\n\n';
+                  message += '```\n';
+                  message += deprecated.join('\n');
+                  message += '\n```\n\n';
+                }
+              }
+            }
+
+            if (hasIssues || message !== '## Bioregistry Collection Issues\n\n') {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: message
+              });
+            }

--- a/.github/workflows/update_bioregistry.yml
+++ b/.github/workflows/update_bioregistry.yml
@@ -1,20 +1,23 @@
 name: Validate Bioregistry Rules
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
   workflow_dispatch:
 
+# This job checks out and executes PR code, including from forks, so it runs
+# with a read-only token and no access to secrets. Reporting results back to the
+# PR happens in a separate, trusted workflow (comment_validation_results.yml)
+# that never executes PR code.
+permissions:
+  contents: read
+
 jobs:
   validate-rules:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,107 +54,20 @@ jobs:
             echo "::error::Some prefixes are not registered in bioregistry.io. Check the logs for details."
           fi
 
-      - name: Create Pull Request Comment
+      - name: Record PR number
         if: always()
-        uses: actions/github-script@v7
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload validation results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ github.token }}
-          script: |
-            const fs = require('fs');
-            let message = '## Bioregistry Collection Issues\n\n';
-            let hasIssues = false;
-            
-            if (fs.existsSync('missing_patterns.txt')) {
-              const missingPatterns = fs.readFileSync('missing_patterns.txt', 'utf8');
-              message += '### Missing Regex Patterns\n\n';
-              message += 'The following resources are missing regex patterns:\n\n';
-              message += '```\n';
-              message += missingPatterns;
-              message += '\n```\n\n';
-              message += 'Please check if these resources are correctly registered in bioregistry.io.\n\n';
-              hasIssues = true;
-            }
-            
-            if (fs.existsSync('duplicates.txt')) {
-              const duplicates = fs.readFileSync('duplicates.txt', 'utf8');
-              message += '### Duplicate Resources\n\n';
-              message += 'The following resources appear multiple times in collection.yaml:\n\n';
-              message += '```\n';
-              message += duplicates;
-              message += '\n```\n\n';
-              message += 'Please remove the duplicate entries.\n\n';
-              hasIssues = true;
-            }
-
-            if (fs.existsSync('invalid_prefixes.txt')) {
-              const invalidPrefixes = fs.readFileSync('invalid_prefixes.txt', 'utf8');
-              message += '### Invalid Prefixes\n\n';
-              message += 'The following prefixes are not registered in bioregistry.io:\n\n';
-              message += '```\n';
-              message += invalidPrefixes;
-              message += '\n```\n\n';
-              message += 'Please check if these prefixes are correct or need to be registered.\n\n';
-              hasIssues = true;
-            }
-
-            // Parse validation.log for missing resolver and deprecated resources
-            if (fs.existsSync('validation.log')) {
-              const log = fs.readFileSync('validation.log', 'utf8');
-              
-              // Extract cross-interference test results
-              const interferenceMatch = log.match(/--- Cross-Interference Test Report ---\s+([\s\S]*?)--------------------------------------/);
-              if (interferenceMatch && interferenceMatch[1]) {
-                const interferenceReport = interferenceMatch[1].trim();
-                if (interferenceReport && !interferenceReport.includes('No cross-interference issues detected')) {
-                  message += '### Cross-Interference Test Results\n\n';
-                  message += 'The following regexes have been identified as causing cross-interference and have been wrapped in non-capturing groups:\n\n';
-                  message += '```\n';
-                  message += interferenceReport;
-                  message += '\n```\n\n';
-                  hasIssues = true;
-                }
-              }
-              
-              // Extract missing resolver resources
-              const missingResolverMatch = log.match(/Missing resolver for the following resources:\s+([\s\S]*?)(?=Deprecated resources detected:|$)/);
-              if (missingResolverMatch && missingResolverMatch[1]) {
-                const missingResolver = missingResolverMatch[1].trim().split('\n').filter(Boolean);
-                if (missingResolver.length > 0) {
-                  message += '### Missing Resolver\n\n';
-                  message += 'The following resources do not have a resolver (uri_format) in bioregistry.io:\n\n';
-                  message += '```\n';
-                  message += missingResolver.join('\n');
-                  message += '\n```\n\n';
-                  message += 'Please check if these resources should have a resolver or be removed.\n\n';
-                  hasIssues = true;
-                }
-              }
-              
-              // Extract deprecated resources
-              const deprecatedMatch = log.match(/Deprecated resources detected:\s+([\s\S]*?)(?=$)/);
-              if (deprecatedMatch && deprecatedMatch[1]) {
-                const deprecated = deprecatedMatch[1].trim().split('\n').filter(Boolean);
-                if (deprecated.length > 0) {
-                  message += '### Deprecated Resources (Warning)\n\n';
-                  message += 'The following resources or prefixes are marked as deprecated in bioregistry.io:\n\n';
-                  message += '```\n';
-                  message += deprecated.join('\n');
-                  message += '\n```\n\n';
-                  message += 'Please check if these resources should be removed or replaced.\n\n';
-                }
-              }
-            }
-
-            if (hasIssues || message !== '## Bioregistry Collection Issues\n\n') {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: message
-              });
-            }
-
-      - name: Cleanup temporary files
-        if: always()
-        run: |
-          rm -f validation.log
+          name: validation-results
+          path: |
+            pr_number.txt
+            validation.log
+            missing_patterns.txt
+            duplicates.txt
+            invalid_prefixes.txt
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
## Problem

The `validate-rules` check fails on fork PRs such as #65:

> Refusing to check out fork pull request code from a `pull_request_target` workflow… commonly leads to "pwn request" vulnerabilities.

The `Validate Bioregistry Rules` workflow ran on `pull_request_target` (base-repo context with a read-write token + secrets), checked out the fork PR's head SHA, and then executed the fork's `generate_bioregistry_rules.py`. GitHub's Sept 2025 security change now blocks checking out fork code under `pull_request_target` by default, so the job dies at checkout before validation runs.

Enabling `allow-unsafe-pr-checkout: true` would restore it but re-open the pwn-request hole (fork code could exfiltrate the write token/secrets), so that's not a safe fix.

## Fix — canonical two-workflow split

- **`update_bioregistry.yml`** now triggers on `pull_request` with `permissions: contents: read` and no secrets. It runs the (untrusted) generator and uploads the report + PR number as an artifact. The check still goes red on validation failure.
- **`comment_validation_results.yml`** (new) triggers on `workflow_run` of the validate workflow. It runs from `main` in a trusted context with `pull-requests: write`, downloads the artifact, and posts the PR comment. It never checks out or executes PR code.

Untrusted PR code and the privileged token no longer share a context, and fork PRs run without any unsafe opt-in. The PR-comment behavior is preserved.

## Notes

- After merge, the comment workflow only appears on PRs opened *after* it lands on `main` (as with any `workflow_run` workflow). Re-running/reopening #65 once this is merged will exercise the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)